### PR TITLE
PYMT-976: Created HasProvider trait and integration tests

### DIFF
--- a/src/Database/Traits/HasProvider.php
+++ b/src/Database/Traits/HasProvider.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Multitenancy\Database\Traits;
+
+use Doctrine\ORM\Mapping as ORM;
+use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+
+/**
+ * @ORM\MappedSuperclass
+ */
+trait HasProvider
+{
+    /**
+     * Relationship to providerId in Provider
+     *
+     * @ORM\ManyToOne(targetEntity="LoyaltyCorp\Multitenancy\Database\Entities\Provider")
+     * @ORM\JoinColumn(name="providerId", referencedColumnName="id", nullable=true)
+     *
+     * @var \LoyaltyCorp\Multitenancy\Database\Entities\Provider
+     */
+    protected $provider;
+
+    /**
+     * Get linked provider to the entity.
+     *
+     * @return \LoyaltyCorp\Multitenancy\Database\Entities\Provider|null
+     */
+    public function getProvider(): ?Provider
+    {
+        return $this->provider;
+    }
+
+    /**
+     * Set provider for the entity.
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider
+     *
+     * @return void
+     */
+    public function setProvider(Provider $provider): void
+    {
+        $this->provider = $provider;
+    }
+}

--- a/tests/Integration/Database/Entities/HasProviderTest.php
+++ b/tests/Integration/Database/Entities/HasProviderTest.php
@@ -8,6 +8,8 @@ use Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityHasProviderS
 use Tests\LoyaltyCorp\Multitenancy\Integration\TestCases\HasProviderTestCase;
 
 /**
+ * This test class tests an entity stub which is using HasProvider trait.
+ *
  * @covers \Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityHasProviderStub
  */
 class HasProviderTest extends HasProviderTestCase

--- a/tests/Integration/Database/Entities/HasProviderTest.php
+++ b/tests/Integration/Database/Entities/HasProviderTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Integration\Database\Entities;
+
+use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+use Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityHasProviderStub;
+use Tests\LoyaltyCorp\Multitenancy\Integration\TestCases\HasProviderTestCase;
+
+/**
+ * @covers \Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityHasProviderStub
+ */
+class HasProviderTest extends HasProviderTestCase
+{
+    /**
+     * Test adding a provider to entity saves state to db.
+     *
+     * @return void
+     */
+    public function testHasProvider(): void
+    {
+        $entityManager = $this->getEntityManager();
+
+        $provider = new Provider('99999991111111aaaaabbbbccccc', 'Acme Corp');
+        $entityManager->persist($provider);
+
+        $entity = new EntityHasProviderStub('ENTITY_ID', 'Test');
+        $entity->setProvider($provider);
+        $entityManager->persist($entity);
+        $entityManager->flush();
+
+        $this->getEntityManager()->clear(EntityHasProviderStub::class);
+        $repository = $entityManager->getRepository(EntityHasProviderStub::class);
+        /**
+         * @var \Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityHasProviderStub $actual
+         */
+        $actual = $repository->findOneBy(['externalId' => 'ENTITY_ID']);
+
+        self::assertSame($provider, $actual->getProvider());
+    }
+
+    /**
+     * Test has provider can accept null provider.
+     *
+     * @return void
+     */
+    public function testHasProviderCanSaveNullProvider(): void
+    {
+        $entityManager = $this->getEntityManager();
+
+        $entity = new EntityHasProviderStub('ENTITY_ID', 'Test');
+        $entityManager->persist($entity);
+        $entityManager->flush();
+
+        $this->getEntityManager()->clear(EntityHasProviderStub::class);
+        $repository = $entityManager->getRepository(EntityHasProviderStub::class);
+        /**
+         * @var \Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityHasProviderStub $actual
+         */
+        $actual = $repository->findOneBy(['externalId' => 'ENTITY_ID']);
+
+        self::assertNull($actual->getProvider());
+    }
+}

--- a/tests/Integration/Stubs/Database/EntityHasProviderStub.php
+++ b/tests/Integration/Stubs/Database/EntityHasProviderStub.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database;
+
+use Doctrine\ORM\Mapping as ORM;
+use LoyaltyCorp\Multitenancy\Database\Traits\HasProvider;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="entity_stub")
+ *
+ * @SuppressWarnings(PHPMD.UnusedPrivateField) Suppress warning about "unused" $entityId.
+ */
+class EntityHasProviderStub
+{
+    use HasProvider;
+
+    /**
+     * @ORM\Column(type="string", name="id")
+     * @ORM\GeneratedValue(strategy="UUID")
+     * @ORM\Id()
+     *
+     * @var int Internal Database ID.
+     */
+    private $entityId;
+
+    /**
+     * @ORM\Column(type="string", nullable=false, unique=true)
+     *
+     * @var string The immutable external ID.
+     */
+    private $externalId;
+
+    /**
+     * @ORM\Column(type="string", nullable=false)
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * EntityHasProviderStub constructor.
+     *
+     * @param string $externalId
+     * @param string $name
+     */
+    public function __construct(string $externalId, string $name)
+    {
+        $this->externalId = $externalId;
+        $this->name = $name;
+    }
+}

--- a/tests/Integration/Stubs/Database/EntityHasProviderStub.php
+++ b/tests/Integration/Stubs/Database/EntityHasProviderStub.php
@@ -7,6 +7,8 @@ use Doctrine\ORM\Mapping as ORM;
 use LoyaltyCorp\Multitenancy\Database\Traits\HasProvider;
 
 /**
+ * This Stub entity is to test HasProvider trait.
+ *
  * @ORM\Entity()
  * @ORM\Table(name="entity_stub")
  *

--- a/tests/Integration/TestCases/HasProviderTestCase.php
+++ b/tests/Integration/TestCases/HasProviderTestCase.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Integration\TestCases;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Setup;
+use Tests\LoyaltyCorp\Multitenancy\DoctrineTestCase;
+
+/**
+ * @coversNothing
+ */
+class HasProviderTestCase extends DoctrineTestCase
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.StaticAccess) Static access to entity manager required to create instance
+     */
+    protected function getDoctrineEntityManager(): EntityManagerInterface
+    {
+        $paths = [__DIR__ . '/../../../src', __DIR__ . '/../Stubs/Database'];
+        $setup = new Setup();
+        $config = $setup::createAnnotationMetadataConfiguration($paths, true, null, null, false);
+        $dbParams = ['driver' => 'pdo_sqlite', 'memory' => true];
+
+        return EntityManager::create($dbParams, $config);
+    }
+}


### PR DESCRIPTION
Ticket [here](https://loyaltycorp.atlassian.net/browse/PYMT-976)

This PR is to be able to have a HasProvider trait which can then be imported into existing entities to add a `provider` relation.