### PR TITLE
PYMT-1085: Updated HasProvider trait to include $providerId

### DIFF
--- a/src/Database/Traits/HasProvider.php
+++ b/src/Database/Traits/HasProvider.php
@@ -22,12 +22,23 @@ trait HasProvider
     protected $provider;
 
     /**
+     * The id of the related provider entity.
+     *
+     * @ORM\Column(type="integer", nullable=true)
+     *
+     * @var int|null
+     */
+    protected $providerId;
+
+    /**
      * Get linked provider to the entity.
      *
      * @return \LoyaltyCorp\Multitenancy\Database\Entities\Provider|null
      */
     public function getProvider(): ?Provider
     {
+        $this->providerId = $this->provider !== null ? $this->provider->getProviderId() : null;
+
         return $this->provider;
     }
 
@@ -41,5 +52,6 @@ trait HasProvider
     public function setProvider(Provider $provider): void
     {
         $this->provider = $provider;
+        $this->providerId = $provider->getProviderId();
     }
 }

--- a/src/Database/Traits/HasProvider.php
+++ b/src/Database/Traits/HasProvider.php
@@ -37,8 +37,6 @@ trait HasProvider
      */
     public function getProvider(): ?Provider
     {
-        $this->providerId = $this->provider !== null ? $this->provider->getProviderId() : null;
-
         return $this->provider;
     }
 

--- a/tests/Stubs/Database/Traits/HasProviderBlankStub.php
+++ b/tests/Stubs/Database/Traits/HasProviderBlankStub.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Stubs\Database\Traits;
+
+use LoyaltyCorp\Multitenancy\Database\Traits\HasProvider;
+
+/**
+ * A blank stub used to test the HasProvider trait.
+ *
+ * @see \Tests\LoyaltyCorp\Multitenancy\Unit\Database\Traits\HasProviderTest
+ *
+ * @coversNothing
+ */
+class EntityHasProviderStub
+{
+    use HasProvider;
+}

--- a/tests/Unit/Database/Traits/HasProviderTest.php
+++ b/tests/Unit/Database/Traits/HasProviderTest.php
@@ -16,10 +16,12 @@ class HasProviderTest extends AppTestCase
      * Tests that the getter returns the same provider instance as what was set through the setter.
      *
      * @return void
+     *
+     * @throws \ReflectionException
      */
     public function testTraitGetterSetter(): void
     {
-        $provider = new Provider('test-provider', 'Test Provider');
+        $provider = $this->getProvider();
         $dummy = new class
         {
             use HasProvider;
@@ -27,5 +29,46 @@ class HasProviderTest extends AppTestCase
         $dummy->setProvider($provider);
 
         self::assertSame($provider, $dummy->getProvider());
+    }
+
+    /**
+     * Tests that when a provider is set, the `providerId` property in the class using the trait has its value updated
+     * to match that of the provider id.
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     */
+    public function testTraitProviderIdSet(): void
+    {
+        $provider = $this->getProvider();
+        $dummy = new class
+        {
+            use HasProvider;
+        };
+        $dummy->setProvider($provider);
+        $property = (new \ReflectionClass($dummy))->getProperty('providerId');
+        $property->setAccessible(true);
+
+        self::assertSame(123, $property->getValue($dummy));
+    }
+
+    /**
+     * Creates a new provider entity instance and sets its id through reflection.
+     *
+     * @return \LoyaltyCorp\Multitenancy\Database\Entities\Provider
+     *
+     * @throws \ReflectionException
+     */
+    private function getProvider(): Provider
+    {
+        $provider = new Provider('test-provider', 'Test Provider');
+
+        $reflection = new \ReflectionClass($provider);
+        $property = $reflection->getProperty('providerId');
+        $property->setAccessible(true);
+        $property->setValue($provider, 123);
+
+        return $provider;
     }
 }

--- a/tests/Unit/Database/Traits/HasProviderTest.php
+++ b/tests/Unit/Database/Traits/HasProviderTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Unit\Database\Traits;
+
+use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+use LoyaltyCorp\Multitenancy\Database\Traits\HasProvider;
+use Tests\LoyaltyCorp\Multitenancy\TestCases\AppTestCase;
+
+/**
+ * @covers \LoyaltyCorp\Multitenancy\Database\Traits\HasProvider
+ */
+class HasProviderTest extends AppTestCase
+{
+    /**
+     * Tests that the getter returns the same provider instance as what was set through the setter.
+     *
+     * @return void
+     */
+    public function testTraitGetterSetter(): void
+    {
+        $provider = new Provider('test-provider', 'Test Provider');
+        $dummy = new class
+        {
+            use HasProvider;
+        };
+        $dummy->setProvider($provider);
+
+        self::assertSame($provider, $dummy->getProvider());
+    }
+}

--- a/tests/Unit/Database/Traits/HasProviderTest.php
+++ b/tests/Unit/Database/Traits/HasProviderTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\Multitenancy\Unit\Database\Traits;
 
 use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
-use LoyaltyCorp\Multitenancy\Database\Traits\HasProvider;
+use ReflectionClass;
+use Tests\LoyaltyCorp\Multitenancy\Stubs\Database\Traits\EntityHasProviderStub;
 use Tests\LoyaltyCorp\Multitenancy\TestCases\AppTestCase;
 
 /**
@@ -21,11 +22,8 @@ class HasProviderTest extends AppTestCase
      */
     public function testTraitGetterSetter(): void
     {
-        $provider = $this->getProvider();
-        $dummy = new class
-        {
-            use HasProvider;
-        };
+        $provider = $this->createProvider();
+        $dummy = new EntityHasProviderStub();
         $dummy->setProvider($provider);
 
         self::assertSame($provider, $dummy->getProvider());
@@ -41,13 +39,10 @@ class HasProviderTest extends AppTestCase
      */
     public function testTraitProviderIdSet(): void
     {
-        $provider = $this->getProvider();
-        $dummy = new class
-        {
-            use HasProvider;
-        };
+        $provider = $this->createProvider();
+        $dummy = new EntityHasProviderStub();
         $dummy->setProvider($provider);
-        $property = (new \ReflectionClass($dummy))->getProperty('providerId');
+        $property = (new ReflectionClass($dummy))->getProperty('providerId');
         $property->setAccessible(true);
 
         self::assertSame(123, $property->getValue($dummy));
@@ -60,11 +55,11 @@ class HasProviderTest extends AppTestCase
      *
      * @throws \ReflectionException
      */
-    private function getProvider(): Provider
+    private function createProvider(): Provider
     {
         $provider = new Provider('test-provider', 'Test Provider');
 
-        $reflection = new \ReflectionClass($provider);
+        $reflection = new ReflectionClass($provider);
         $property = $reflection->getProperty('providerId');
         $property->setAccessible(true);
         $property->setValue($provider, 123);


### PR DESCRIPTION
This PR is adds the `$providerId` property to the `HasProvider` trait to provide visibility to Laravel's validator and allow the unique constraint validation rule in Subscriptions to work.