### PR TITLE
PYMT-1085: Removed join from HasProvider trait

### DIFF
--- a/src/Database/Traits/HasProvider.php
+++ b/src/Database/Traits/HasProvider.php
@@ -15,7 +15,6 @@ trait HasProvider
      * Relationship to providerId in Provider
      *
      * @ORM\ManyToOne(targetEntity="LoyaltyCorp\Multitenancy\Database\Entities\Provider")
-     * @ORM\JoinColumn(name="providerId", referencedColumnName="id", nullable=true)
      *
      * @var \LoyaltyCorp\Multitenancy\Database\Entities\Provider
      */


### PR DESCRIPTION
In this PR, the join is removed for provider in the HasProvider trait. It is no longer required.