### PR TITLE
PYMT-981 Enhance database management for multitenancy

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * PhpStorm metadata file, helps PhpStorm understand what is returned by certain factories/methods
+ * where typehints aren't available (e.g. mixed or an interface rather than a concrete class)
+ *
+ * @see https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html
+ */
+
+namespace PHPSTORM_META {
+
+    override(\LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\EntityManagerInterface::getRepository(0), map([
+        '' => \LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\RepositoryInterface::class
+    ]));
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,11 +7,11 @@ parameters:
             message: '/Call to an undefined method object::getProvider\(\)./'
             path: src/Externals/ORM/Subscribers/ProtectedFlushSubscriber.php
         -
-            message: '/Parameter \#1 \$className \(string\) of method Tests\\LoyaltyCorp\\Multitenancy\\Stubs\\Vendor\\Doctrine\\EntityManagerStub::getClassMetadata\(\) should be contravariant with parameter \$className \(mixed\) of method Doctrine\\ORM\\EntityManagerInterface::getClassMetadata\(\)/'
-            path: tests/Stubs/Vendor/Doctrine/EntityManagerStub.php
+            message: '/Parameter \#1 \$className \(string\) of method Tests\\LoyaltyCorp\\Multitenancy\\Stubs\\Vendor\\Doctrine\\ORM\\EntityManagerStub::getClassMetadata\(\) should be contravariant with parameter \$className \(mixed\) of method Doctrine\\ORM\\EntityManagerInterface::getClassMetadata\(\)/'
+            path: tests/Stubs/Vendor/Doctrine/ORM/EntityManagerStub.php
         -
-            message: '/Return type \(Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata\) of method Tests\\LoyaltyCorp\\Multitenancy\\Stubs\\Vendor\\Doctrine\\EntityManagerStub::getClassMetadata\(\) should be covariant with return type \(Doctrine\\ORM\\Mapping\\ClassMetadata\) of method Doctrine\\ORM\\EntityManagerInterface::getClassMetadata\(\)/'
-            path: tests/Stubs/Vendor/Doctrine/EntityManagerStub.php
+            message: '/Return type \(Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata\) of method Tests\\LoyaltyCorp\\Multitenancy\\Stubs\\Vendor\\Doctrine\\ORM\\EntityManagerStub::getClassMetadata\(\) should be covariant with return type \(Doctrine\\ORM\\Mapping\\ClassMetadata\) of method Doctrine\\ORM\\EntityManagerInterface::getClassMetadata\(\)/'
+            path: tests/Stubs/Vendor/Doctrine/ORM/EntityManagerStub.php
         -
             message: '#Call to function is_array\(\) with object|string will always evaluate to false\.#'
             path: src/Middleware/ProviderMiddleware.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,3 +27,15 @@ parameters:
         -
             message: '/Method Tests\\LoyaltyCorp\\Multitenancy\\Stubs\\Externals\\FlowConfig\\DoctrineEntityConfigStub::setByEntity\(\) has parameter \$value with no typehint specified\./'
             path: tests/Stubs/Externals/FlowConfig/DoctrineEntityConfigStub.php
+        -
+            message: '/Parameter #2 \$entity of method LoyaltyCorp\\Multitenancy\\Externals\\Interfaces\\ORM\\EntityManagerInterface::findByIds\(\) expects object\|string, array given./'
+            path: tests/Unit/Externals/ORM/EntityManagerTest.php
+        -
+            message: '#Call to function is_object\(\) with object will always evaluate to true.#'
+            path: src/Externals/ORM/EntityManager.php
+        -
+            message: '#Result of && is always false.#'
+            path: src/Externals/ORM/EntityManager.php
+        -
+            message: '#Strict comparison using === between true and false will always evaluate to false.#'
+            path: src/Externals/ORM/EntityManager.php

--- a/src/Database/Exceptions/InvalidEntityException.php
+++ b/src/Database/Exceptions/InvalidEntityException.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Multitenancy\Database\Exceptions;
+
+use EoneoPay\Utils\Exceptions\RuntimeException;
+
+final class InvalidEntityException extends RuntimeException
+{
+    /**
+     * Get Error code.
+     *
+     * @return int
+     */
+    public function getErrorCode(): int
+    {
+        return self::DEFAULT_ERROR_CODE_RUNTIME + 29;
+    }
+
+    /**
+     * Get Error sub-code.
+     *
+     * @return int
+     */
+    public function getErrorSubCode(): int
+    {
+        return 3;
+    }
+}

--- a/src/Database/Exceptions/ProviderAlreadySetException.php
+++ b/src/Database/Exceptions/ProviderAlreadySetException.php
@@ -5,7 +5,7 @@ namespace LoyaltyCorp\Multitenancy\Database\Exceptions;
 
 use EoneoPay\Utils\Exceptions\RuntimeException;
 
-final class InvalidEntityOwnershipException extends RuntimeException
+final class ProviderAlreadySetException extends RuntimeException
 {
     /**
      * Get Error code.
@@ -24,6 +24,6 @@ final class InvalidEntityOwnershipException extends RuntimeException
      */
     public function getErrorSubCode(): int
     {
-        return 1;
+        return 2;
     }
 }

--- a/src/Database/Interfaces/HasProviderInterface.php
+++ b/src/Database/Interfaces/HasProviderInterface.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Multitenancy\Database\Interfaces;
+
+use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+
+interface HasProviderInterface
+{
+    /**
+     * Get linked provider to the entity.
+     *
+     * @return \LoyaltyCorp\Multitenancy\Database\Entities\Provider|null
+     */
+    public function getProvider(): ?Provider;
+
+    /**
+     * Get provider id from provider entity
+     *
+     * @return int|null
+     */
+    public function getProviderId(): ?int;
+
+    /**
+     * Set provider for the entity.
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider
+     *
+     * @return mixed Returns self for fluency
+     */
+    public function setProvider(Provider $provider);
+}

--- a/src/Database/Traits/HasProvider.php
+++ b/src/Database/Traits/HasProvider.php
@@ -5,6 +5,7 @@ namespace LoyaltyCorp\Multitenancy\Database\Traits;
 
 use Doctrine\ORM\Mapping as ORM;
 use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+use LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException;
 
 /**
  * @ORM\MappedSuperclass
@@ -40,14 +41,33 @@ trait HasProvider
     }
 
     /**
+     * Get provider id from provider entity
+     *
+     * @return int|null
+     */
+    public function getProviderId(): ?int
+    {
+        return ($this->getProvider() instanceof Provider) === true ? $this->getProvider()->getProviderId() : null;
+    }
+
+    /**
      * Set provider for the entity.
      *
      * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider
      *
      * @return mixed Returns self for fluency
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException If provider clashes
      */
     public function setProvider(Provider $provider)
     {
+        // If provider is already set and it's not the same as what was passed through, deny
+        if (($this->getProvider() instanceof Provider) === true && $this->getProvider() !== $provider) {
+            throw new ProviderAlreadySetException(
+                'A provider has already been set on this entity and can not be changed.'
+            );
+        }
+
         $this->provider = $provider;
         $this->providerId = $provider->getProviderId();
 

--- a/src/Externals/Interfaces/ORM/EntityManagerInterface.php
+++ b/src/Externals/Interfaces/ORM/EntityManagerInterface.php
@@ -15,7 +15,7 @@ interface EntityManagerInterface
      * Does NOT currently support composite identifiers.
      *
      * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider Provider who should own this entity
-     * @param mixed $entity An entity object or string containing a class name
+     * @param object|string $entity An entity object or string containing a class name
      * @param mixed[] $ids Multiple ids to find entities by
      *
      * @return object[]

--- a/src/Externals/Interfaces/ORM/EntityManagerInterface.php
+++ b/src/Externals/Interfaces/ORM/EntityManagerInterface.php
@@ -4,9 +4,24 @@ declare(strict_types=1);
 namespace LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM;
 
 use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+use LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface;
+use LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\Query\FilterCollectionInterface;
 
 interface EntityManagerInterface
 {
+    /**
+     * Finds an entity by its identifier.
+     *
+     * Does NOT currently support composite identifiers.
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider Provider who should own this entity
+     * @param \LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface $entity The entity to find by ids
+     * @param mixed[] $ids Multiple ids to find entities by
+     *
+     * @return object[]
+     */
+    public function findByIds(Provider $provider, HasProviderInterface $entity, array $ids): array;
+
     /**
      * Flush unit of work to the database, ensuring all entities belong to the correct provider if applicable
      *
@@ -15,6 +30,13 @@ interface EntityManagerInterface
      * @return void
      */
     public function flush(Provider $provider): void;
+
+    /**
+     * Gets the filters attached to the entity manager.
+     *
+     * @return \LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\Query\FilterCollectionInterface
+     */
+    public function getFilters(): FilterCollectionInterface;
 
     /**
      * Gets the repository from a entity class
@@ -26,20 +48,32 @@ interface EntityManagerInterface
     public function getRepository(string $class);
 
     /**
-     * Persist entity to the database
+     * Merge entity to the database, similar to REPLACE INTO in SQL
      *
-     * @param object $entity The entity to persist to the database
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider Provider who should own this entity
+     * @param \LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface $entity The entity to merge
      *
      * @return void
      */
-    public function persist(object $entity): void;
+    public function merge(Provider $provider, HasProviderInterface $entity): void;
+
+    /**
+     * Persist entity to the database
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider Provider who should own this entity
+     * @param \LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface $entity The entity to persist
+     *
+     * @return void
+     */
+    public function persist(Provider $provider, HasProviderInterface $entity): void;
 
     /**
      * Remove entity from the database.
      *
-     * @param object $entity The entity to remove from the database
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider Provider who should own this entity
+     * @param \LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface $entity The entity to remove
      *
      * @return void
      */
-    public function remove(object $entity): void;
+    public function remove(Provider $provider, HasProviderInterface $entity): void;
 }

--- a/src/Externals/Interfaces/ORM/EntityManagerInterface.php
+++ b/src/Externals/Interfaces/ORM/EntityManagerInterface.php
@@ -15,12 +15,12 @@ interface EntityManagerInterface
      * Does NOT currently support composite identifiers.
      *
      * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider Provider who should own this entity
-     * @param \LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface $entity The entity to find by ids
+     * @param mixed $entity An entity object or string containing a class name
      * @param mixed[] $ids Multiple ids to find entities by
      *
      * @return object[]
      */
-    public function findByIds(Provider $provider, HasProviderInterface $entity, array $ids): array;
+    public function findByIds(Provider $provider, $entity, array $ids): array;
 
     /**
      * Flush unit of work to the database, ensuring all entities belong to the correct provider if applicable

--- a/src/Externals/Interfaces/ORM/Query/FilterCollectionInterface.php
+++ b/src/Externals/Interfaces/ORM/Query/FilterCollectionInterface.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\Query;
+
+interface FilterCollectionInterface
+{
+    /**
+     * Disables a filter.
+     *
+     * @param string $name Name of the filter.
+     *
+     * @return void.
+     *
+     * @phpcsSuppress EoneoPay.Commenting.FunctionComment.ScalarTypeHintMissing
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     */
+    public function disable($name): void;
+
+    /**
+     * Enables a filter from the collection.
+     *
+     * @param string $name Name of the filter.
+     *
+     * @return void
+     *
+     * @phpcsSuppress EoneoPay.Commenting.FunctionComment.ScalarTypeHintMissing
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     */
+    public function enable($name): void;
+}

--- a/src/Externals/Interfaces/ORM/RepositoryInterface.php
+++ b/src/Externals/Interfaces/ORM/RepositoryInterface.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM;
+
+use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+
+interface RepositoryInterface
+{
+    /**
+     * Counts entities by a set of criteria.
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider The provider to limit search criteria to
+     * @param mixed[]|null $criteria The search criteria
+     *
+     * @return int The cardinality of the objects matching search criteria
+     */
+    public function count(Provider $provider, ?array $criteria = null): int;
+
+    /**
+     * Finds an object by its primary key / identifier.
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider
+     * @param mixed $entityId The entity identifier
+     *
+     * @return object|null The entity matching the identifier or null if no matching entity found
+     */
+    public function find(Provider $provider, $entityId): ?object;
+
+    /**
+     * Finds all objects in the repository.
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider The provider to limit search criteria to
+     *
+     * @return object[] All matching entities
+     */
+    public function findAll(Provider $provider): array;
+
+    /**
+     * Finds objects by a set of criteria.
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider The provider to limit search criteria to
+     * @param mixed[] $criteria The search criteria
+     * @param string[]|null $orderBy How to order results
+     * @param int|null $limit The number of results to retrieve
+     * @param int|null $offset Number of records to skip when searching
+     *
+     * @return object[] Entities matching search criteria
+     */
+    public function findBy(
+        Provider $provider,
+        array $criteria,
+        ?array $orderBy = null,
+        ?int $limit = null,
+        ?int $offset = null
+    ): array;
+
+    /**
+     * Finds a single object by a set of criteria.
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider The provider to limit search criteria to
+     * @param mixed[] $criteria The search criteria
+     * @param string[]|null $orderBy How to order results
+     *
+     * @return object|null First entity matching search criteria or null if no matches found
+     */
+    public function findOneBy(Provider $provider, array $criteria, ?array $orderBy = null): ?object;
+
+    /**
+     * Returns the class name of the object managed by the repository.
+     *
+     * @return string
+     */
+    public function getClassName(): string;
+}

--- a/src/Externals/ORM/EntityManager.php
+++ b/src/Externals/ORM/EntityManager.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 namespace LoyaltyCorp\Multitenancy\Externals\ORM;
 
 use Doctrine\ORM\EntityManagerInterface as DoctrineEntityManager;
+use Doctrine\ORM\Mapping\MappingException;
 use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+use LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface;
 use LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\EntityManagerInterface;
+use LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\Query\FilterCollectionInterface;
+use LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\RepositoryInterface;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\InvalidRepositoryException;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Query\FilterCollection;
 use LoyaltyCorp\Multitenancy\Externals\ORM\Subscribers\ProtectedFlushSubscriber;
 
 final class EntityManager implements EntityManagerInterface
@@ -29,6 +36,37 @@ final class EntityManager implements EntityManagerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If entity uses composite identifiers
+     */
+    public function findByIds(Provider $provider, HasProviderInterface $entity, array $ids): array
+    {
+        $class = \get_class($entity);
+
+        $metadata = $this->entityManager->getClassMetadata($class);
+
+        try {
+            $field = \sprintf('e.%s', $metadata->getSingleIdentifierFieldName());
+        } catch (MappingException $exception) {
+            // Exception only thrown when composite identifiers are used
+            throw new ORMException(\sprintf('Database Error: %s', $exception->getMessage()), null, null, $exception);
+        }
+
+        // Create query
+        $builder = $this->entityManager->createQueryBuilder();
+        $builder
+            ->select('e')
+            ->from($class, 'e')
+            ->where('IDENTITY(e.provider) = :provider')
+            ->andWhere($builder->expr()->in($field, ':ids'))
+            ->setParameter('provider', $provider)
+            ->setParameter('ids', $ids);
+
+        return $builder->getQuery()->getResult();
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function flush(Provider $provider): void
     {
@@ -48,24 +86,61 @@ final class EntityManager implements EntityManagerInterface
     /**
      * {@inheritdoc}
      */
+    public function getFilters(): FilterCollectionInterface
+    {
+        return new FilterCollection($this->entityManager->getFilters());
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\InvalidRepositoryException If repository isn't mtenant
+     */
     public function getRepository(string $class)
     {
-        return $this->entityManager->getRepository($class);
+        $repository = $this->entityManager->getRepository($class);
+
+        // Repository must be a multitenancy repository or die
+        if (($repository instanceof RepositoryInterface) === false) {
+            throw new InvalidRepositoryException(\sprintf(
+                'Invalid repository. %s does not implement multitenancy repository interface.',
+                \get_class($repository)
+            ));
+        }
+
+        return $repository;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function persist($entity): void
+    public function merge(Provider $provider, HasProviderInterface $entity): void
     {
+        // Force provider on entity
+        $entity->setProvider($provider);
+
+        $this->entityManager->merge($entity);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function persist(Provider $provider, HasProviderInterface $entity): void
+    {
+        // Force provider on entity
+        $entity->setProvider($provider);
+
         $this->entityManager->persist($entity);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function remove($entity): void
+    public function remove(Provider $provider, HasProviderInterface $entity): void
     {
+        // Force provider on entity
+        $entity->setProvider($provider);
+
         $this->entityManager->remove($entity);
     }
 }

--- a/src/Externals/ORM/Exceptions/InvalidRepositoryException.php
+++ b/src/Externals/ORM/Exceptions/InvalidRepositoryException.php
@@ -1,11 +1,11 @@
 <?php
 declare(strict_types=1);
 
-namespace LoyaltyCorp\Multitenancy\Database\Exceptions;
+namespace LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions;
 
 use EoneoPay\Utils\Exceptions\RuntimeException;
 
-final class InvalidEntityOwnershipException extends RuntimeException
+final class InvalidRepositoryException extends RuntimeException
 {
     /**
      * Get Error code.
@@ -24,6 +24,6 @@ final class InvalidEntityOwnershipException extends RuntimeException
      */
     public function getErrorSubCode(): int
     {
-        return 1;
+        return 10;
     }
 }

--- a/src/Externals/ORM/Exceptions/ORMException.php
+++ b/src/Externals/ORM/Exceptions/ORMException.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions;
+
+use EoneoPay\Utils\Exceptions\CriticalException;
+
+final class ORMException extends CriticalException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return self::DEFAULT_ERROR_CODE_CRITICAL + 29;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorMessage(): string
+    {
+        return 'A database error occurred.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+}

--- a/src/Externals/ORM/Query/FilterCollection.php
+++ b/src/Externals/ORM/Query/FilterCollection.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Multitenancy\Externals\ORM\Query;
+
+use Doctrine\ORM\Query\FilterCollection as DoctrineFilterCollection;
+use InvalidArgumentException;
+use LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\Query\FilterCollectionInterface;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException;
+
+final class FilterCollection implements FilterCollectionInterface
+{
+    /**
+     * @var \Doctrine\ORM\Query\FilterCollection
+     */
+    private $collection;
+
+    /**
+     * Create a new filter collection from a Doctrine FilterCollection.
+     *
+     * @param \Doctrine\ORM\Query\FilterCollection $filterCollection
+     */
+    public function __construct(DoctrineFilterCollection $filterCollection)
+    {
+        $this->collection = $filterCollection;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If the filter does not exist
+     */
+    public function disable($name): void
+    {
+        $this->callMethod('disable', $name);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If the filter does not exist
+     */
+    public function enable($name): void
+    {
+        $this->callMethod('enable', $name);
+    }
+
+    /**
+     * Call a method on the entity manager and catch any exception
+     *
+     * @param string $method The method to call
+     * @param mixed ...$parameters The parameters to pass to the method
+     *
+     * @return mixed
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If the filter does not exist
+     */
+    private function callMethod(string $method, ...$parameters)
+    {
+        try {
+            $callable = [$this->collection, $method];
+
+            if (\is_callable($callable)) {
+                return \call_user_func_array($callable, $parameters ?? []);
+            }
+        } catch (InvalidArgumentException $exception) {
+            // Wrap exceptions in ORMException
+            throw new ORMException(\sprintf('Database Error: %s', $exception->getMessage()), null, null, $exception);
+        }
+    }
+}

--- a/src/Externals/ORM/Repository.php
+++ b/src/Externals/ORM/Repository.php
@@ -1,0 +1,192 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Multitenancy\Externals\ORM;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\MappingException;
+use Doctrine\ORM\QueryBuilder;
+use Exception;
+use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+use LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\RepositoryInterface;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException;
+
+abstract class Repository implements RepositoryInterface
+{
+    /**
+     * @var \Doctrine\ORM\Mapping\ClassMetadata
+     */
+    protected $classMetadata;
+
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * Initialise a new repository
+     *
+     * @param \Doctrine\ORM\EntityManagerInterface $entityManager Entity manager instance
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $classMetadata The class descriptor
+     */
+    public function __construct(EntityManagerInterface $entityManager, ClassMetadata $classMetadata)
+    {
+        $this->classMetadata = $classMetadata;
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If there is a db or Doctrine ORM error
+     */
+    public function count(Provider $provider, ?array $criteria = null): int
+    {
+        return $this->callMethod('count', $this->createCriteria($provider, $criteria));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.ShortVariable) Parameter is inherited from interface
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If entity uses composite primary key
+     */
+    public function find(Provider $provider, $entityId): ?object
+    {
+        return $this->findOneBy($provider, [$this->getIdProperty() => $entityId]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If there is a db or Doctrine ORM error
+     */
+    public function findAll(Provider $provider): array
+    {
+        return $this->findBy($provider, []);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If there is a db or Doctrine ORM error
+     */
+    public function findBy(
+        Provider $provider,
+        array $criteria,
+        ?array $orderBy = null,
+        ?int $limit = null,
+        ?int $offset = null
+    ): array {
+        $found = $this->callMethod(
+            'loadAll',
+            $this->createCriteria($provider, $criteria),
+            $orderBy,
+            $limit,
+            $offset
+        );
+
+        return $found ?? [];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If there is a db or Doctrine ORM error
+     */
+    public function findOneBy(Provider $provider, array $criteria, ?array $orderBy = null): ?object
+    {
+        return $this->callMethod(
+            'load',
+            $this->createCriteria($provider, $criteria),
+            null,
+            null,
+            [],
+            null,
+            1,
+            $orderBy
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClassName(): string
+    {
+        return $this->classMetadata->name;
+    }
+
+    /**
+     * Create query build instance
+     *
+     * @param string $alias The select alias
+     * @param string|null $indexBy The index to use
+     *
+     * @return \Doctrine\ORM\QueryBuilder
+     */
+    protected function createQueryBuilder(string $alias, ?string $indexBy = null): QueryBuilder
+    {
+        return $this->entityManager->createQueryBuilder()
+            ->select($alias)
+            ->from($this->classMetadata->name, $alias, $indexBy);
+    }
+
+    /**
+     * Call a method on the entity manager and catch any exception
+     *
+     * @param string $method The method torc/ORM/Subscribers/SoftDeleteEventSubscriber.php call
+     * @param mixed ...$parameters The parameters to pass to the method
+     *
+     * @return mixed
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If there is a db or Doctrine ORM error
+     */
+    private function callMethod(string $method, ...$parameters)
+    {
+        try {
+            // Get persister
+            $persister = $this->entityManager->getUnitOfWork()->getEntityPersister($this->classMetadata->name);
+
+            $callable = [$persister, $method];
+
+            if (\is_callable($callable)) {
+                return \call_user_func_array($callable, $parameters ?? []);
+            }
+        } catch (Exception $exception) {
+            // Wrap all thrown exceptions as an ORM exception
+            throw new ORMException(\sprintf('Database Error: %s', $exception->getMessage()), null, null, $exception);
+        }
+    }
+
+    /**
+     * Create criteria forcing provider
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider The provider who should own entities
+     * @param mixed[]|null $criteria The search criteria
+     *
+     * @return mixed[]
+     */
+    private function createCriteria(Provider $provider, ?array $criteria = null): array
+    {
+        return \array_merge($criteria ?? [], ['provider' => $provider]);
+    }
+
+    /**
+     * Get id property for the underlying entity
+     *
+     * @return string
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException If entity uses composite primary key
+     */
+    private function getIdProperty(): string
+    {
+        // Attempt to get single id column, will throw exception if composite id column is found on entity
+        try {
+            return $this->classMetadata->getSingleIdentifierFieldName();
+        } catch (MappingException $exception) {
+            throw new ORMException(\sprintf('Database Error: %s', $exception->getMessage()), null, null, $exception);
+        }
+    }
+}

--- a/tests/Integration/Database/Entities/HasProviderTest.php
+++ b/tests/Integration/Database/Entities/HasProviderTest.php
@@ -18,6 +18,8 @@ class HasProviderTest extends HasProviderTestCase
      * Test adding a provider to entity saves state to db.
      *
      * @return void
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException If provider clashes
      */
     public function testHasProvider(): void
     {
@@ -68,6 +70,8 @@ class HasProviderTest extends HasProviderTestCase
      * Test fluency
      *
      * @return void
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException If provider clashes
      */
     public function testHasProviderIsFluent(): void
     {

--- a/tests/Integration/Stubs/Database/EntityDoesNotHaveProviderStub.php
+++ b/tests/Integration/Stubs/Database/EntityDoesNotHaveProviderStub.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * This stub has a repository with the right interface.
+ *
+ * @ORM\Entity()
+ */
+final class EntityDoesNotHaveProviderStub
+{
+    /**
+     * @ORM\Column(type="string", name="id")
+     * @ORM\GeneratedValue(strategy="UUID")
+     * @ORM\Id()
+     *
+     * @var string Internal Database ID.
+     */
+    private $entityId;
+
+    /**
+     * Get entity id
+     *
+     * @return string|null
+     */
+    public function getEntityId(): ?string
+    {
+        return $this->entityId;
+    }
+}

--- a/tests/Integration/Stubs/Database/EntityDoesNotImplementRepositoryInterfaceStub.php
+++ b/tests/Integration/Stubs/Database/EntityDoesNotImplementRepositoryInterfaceStub.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database;
+
+use Doctrine\ORM\Mapping as ORM;
+use LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface;
+use LoyaltyCorp\Multitenancy\Database\Traits\HasProvider;
+
+/**
+ * This stub does not have a repository with the right interface.
+ *
+ * @ORM\Entity()
+ */
+final class EntityDoesNotImplementRepositoryInterfaceStub implements HasProviderInterface
+{
+    use HasProvider;
+
+    /**
+     * @ORM\Column(type="string", name="id")
+     * @ORM\GeneratedValue(strategy="UUID")
+     * @ORM\Id()
+     *
+     * @var string Internal Database ID.
+     */
+    private $entityId;
+
+    /**
+     * Get generated entity id
+     *
+     * @return string|null
+     */
+    public function getEntityId(): ?string
+    {
+        return $this->entityId;
+    }
+}

--- a/tests/Integration/Stubs/Database/EntityHasCompositePrimaryKeyStub.php
+++ b/tests/Integration/Stubs/Database/EntityHasCompositePrimaryKeyStub.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database;
+
+use Doctrine\ORM\Mapping as ORM;
+use LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface;
+use LoyaltyCorp\Multitenancy\Database\Traits\HasProvider;
+
+/**
+ * This stub has composite primary keys.
+ *
+ * @ORM\Entity(repositoryClass="\Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\RepositoryStub")
+ */
+final class EntityHasCompositePrimaryKeyStub implements HasProviderInterface
+{
+    use HasProvider;
+
+    /**
+     * @ORM\Column(type="string", nullable=false, unique=true)
+     * @ORM\Id()
+     *
+     * @var string The immutable external ID.
+     */
+    private $externalId;
+
+    /**
+     * @ORM\Column(type="string", nullable=false)
+     * @ORM\Id()
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * EntityHasProviderStub constructor.
+     *
+     * @param string $externalId
+     * @param string $name
+     */
+    public function __construct(string $externalId, string $name)
+    {
+        $this->externalId = $externalId;
+        $this->name = $name;
+    }
+}

--- a/tests/Integration/Stubs/Database/EntityHasProviderStub.php
+++ b/tests/Integration/Stubs/Database/EntityHasProviderStub.php
@@ -6,15 +6,15 @@ namespace Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface;
 use LoyaltyCorp\Multitenancy\Database\Traits\HasProvider;
 
 /**
- * This Stub entity is to test HasProvider trait.
+ * This stub entity is to test HasProvider trait.
  *
  * @ORM\Entity()
- * @ORM\Table()
  */
-class EntityHasProviderStub
+class EntityHasProviderStub implements HasProviderInterface
 {
     use HasProvider;
 
@@ -91,6 +91,16 @@ class EntityHasProviderStub
     }
 
     /**
+     * Get external id set in constructor
+     *
+     * @return string
+     */
+    public function getExternalId(): string
+    {
+        return $this->externalId;
+    }
+
+    /**
      * Get owned collection
      *
      * @return \Doctrine\Common\Collections\Collection
@@ -98,6 +108,20 @@ class EntityHasProviderStub
     public function getOwned(): Collection
     {
         return $this->owned;
+    }
+
+    /**
+     * Set entity id
+     *
+     * @param string $entityId The id to set against the entity
+     *
+     * @return mixed
+     */
+    public function setEntityId(string $entityId)
+    {
+        $this->entityId = $entityId;
+
+        return $this;
     }
 
     /**

--- a/tests/Integration/Stubs/Database/EntityImplementsRepositoryInterfaceStub.php
+++ b/tests/Integration/Stubs/Database/EntityImplementsRepositoryInterfaceStub.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database;
+
+use Doctrine\ORM\Mapping as ORM;
+use LoyaltyCorp\Multitenancy\Database\Interfaces\HasProviderInterface;
+use LoyaltyCorp\Multitenancy\Database\Traits\HasProvider;
+
+/**
+ * This stub has a repository with the right interface.
+ *
+ * @ORM\Entity(repositoryClass="\Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\RepositoryStub")
+ */
+final class EntityImplementsRepositoryInterfaceStub implements HasProviderInterface
+{
+    use HasProvider;
+
+    /**
+     * @ORM\Column(type="string", name="id")
+     * @ORM\GeneratedValue(strategy="UUID")
+     * @ORM\Id()
+     *
+     * @var string Internal Database ID.
+     */
+    private $entityId;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @var string
+     */
+    private $string;
+
+    /**
+     * Create entity stub
+     *
+     * @param string $string
+     */
+    public function __construct(string $string)
+    {
+        $this->string = $string;
+    }
+
+    /**
+     * Get entity id
+     *
+     * @return string|null
+     */
+    public function getEntityId(): ?string
+    {
+        return $this->entityId;
+    }
+}

--- a/tests/Integration/Stubs/Database/RepositoryStub.php
+++ b/tests/Integration/Stubs/Database/RepositoryStub.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database;
+
+use LoyaltyCorp\Multitenancy\Externals\ORM\Repository;
+
+/**
+ * This stub allows the repository to be used.
+ */
+final class RepositoryStub extends Repository
+{
+}

--- a/tests/Stubs/Vendor/Doctrine/ORM/EntityManagerStub.php
+++ b/tests/Stubs/Vendor/Doctrine/ORM/EntityManagerStub.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine;
+namespace Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine\ORM;
 
 use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;

--- a/tests/Stubs/Vendor/Doctrine/ORM/Query/FilterStub.php
+++ b/tests/Stubs/Vendor/Doctrine/ORM/Query/FilterStub.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine\ORM\Query;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Query\Filter\SQLFilter;
+
+class FilterStub extends SQLFilter
+{
+    /**
+     * Add filter constraint
+     *
+     * @param \Doctrine\ORM\Mapping\ClassMetadata $targetEntity The entity to add the constraint to
+     * @param string|mixed $targetTableAlias The target table
+     *
+     * @return string
+     */
+    public function addFilterConstraint(ClassMetadata $targetEntity, $targetTableAlias): string
+    {
+        return $targetEntity->name ?? $targetTableAlias;
+    }
+}

--- a/tests/Unit/Database/Exceptions/InvalidEntityExceptionTest.php
+++ b/tests/Unit/Database/Exceptions/InvalidEntityExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Unit\Database\Exceptions;
+
+use LoyaltyCorp\Multitenancy\Database\Exceptions\InvalidEntityException;
+use Tests\LoyaltyCorp\Multitenancy\TestCases\AppTestCase;
+
+/**
+ * @covers \LoyaltyCorp\Multitenancy\Database\Exceptions\InvalidEntityException
+ */
+final class InvalidEntityExceptionTest extends AppTestCase
+{
+    /**
+     * Test exception returns the correct codes
+     *
+     * @return void
+     */
+    public function testExceptionCodes(): void
+    {
+        $exception = new InvalidEntityException();
+
+        self::assertSame(1129, $exception->getErrorCode());
+        self::assertSame(3, $exception->getErrorSubCode());
+    }
+}

--- a/tests/Unit/Database/Exceptions/ProviderAlreadySetExceptionTest.php
+++ b/tests/Unit/Database/Exceptions/ProviderAlreadySetExceptionTest.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\Multitenancy\Unit\Database\Exceptions;
 
-use LoyaltyCorp\Multitenancy\Database\Exceptions\InvalidEntityOwnershipException;
+use LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException;
 use Tests\LoyaltyCorp\Multitenancy\TestCases\AppTestCase;
 
 /**
- * @covers \LoyaltyCorp\Multitenancy\Database\Exceptions\InvalidEntityOwnershipException
+ * @covers \LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException
  */
-final class InvalidEntityOwnershipExceptionTest extends AppTestCase
+final class ProviderAlreadySetExceptionTest extends AppTestCase
 {
     /**
      * Test exception returns the correct codes
@@ -18,9 +18,9 @@ final class InvalidEntityOwnershipExceptionTest extends AppTestCase
      */
     public function testExceptionCodes(): void
     {
-        $exception = new InvalidEntityOwnershipException();
+        $exception = new ProviderAlreadySetException();
 
         self::assertSame(1129, $exception->getErrorCode());
-        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame(2, $exception->getErrorSubCode());
     }
 }

--- a/tests/Unit/Database/Seeders/ProviderSeederTest.php
+++ b/tests/Unit/Database/Seeders/ProviderSeederTest.php
@@ -6,7 +6,7 @@ namespace Tests\LoyaltyCorp\Multitenancy\Unit\Database\Seeders;
 use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
 use LoyaltyCorp\Multitenancy\Database\Seeders\ProviderSeeder;
 use PHPUnit\Framework\TestCase;
-use Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine\EntityManagerStub;
+use Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine\ORM\EntityManagerStub;
 
 /**
  * @covers \LoyaltyCorp\Multitenancy\Database\Seeders\ProviderSeeder

--- a/tests/Unit/Externals/ORM/EntityManagerTest.php
+++ b/tests/Unit/Externals/ORM/EntityManagerTest.php
@@ -4,21 +4,104 @@ declare(strict_types=1);
 namespace Tests\LoyaltyCorp\Multitenancy\Unit\Externals\ORM;
 
 use Doctrine\ORM\EntityManagerInterface as DoctrineEntityManager;
-use Doctrine\ORM\EntityRepository;
 use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
 use LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\EntityManagerInterface;
+use LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\RepositoryInterface;
 use LoyaltyCorp\Multitenancy\Externals\ORM\EntityManager;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\InvalidRepositoryException;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException;
 use LoyaltyCorp\Multitenancy\Externals\ORM\Subscribers\ProtectedFlushSubscriber;
+use Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityDoesNotImplementRepositoryInterfaceStub;
+use Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityHasCompositePrimaryKeyStub;
 use Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityHasProviderStub;
+use Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityImplementsRepositoryInterfaceStub;
 use Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine\Common\EventManagerStub;
-use Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine\EntityManagerStub;
+use Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine\ORM\EntityManagerStub;
+use Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine\ORM\Query\FilterStub;
 use Tests\LoyaltyCorp\Multitenancy\TestCases\DoctrineTestCase;
 
 /**
  * @covers \LoyaltyCorp\Multitenancy\Externals\ORM\EntityManager
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) High coupling required to fully test aspects of entity manager
  */
 final class EntityManagerTest extends DoctrineTestCase
 {
+    /**
+     * Test repository method findByIds
+     *
+     * @return void
+     */
+    public function testFindByIdsFindsEntities(): void
+    {
+        // Create doctrine instance and get filters
+        $doctrine = $this->getEntityManager();
+
+        // Create entity manager instance
+        $instance = $this->createInstance($doctrine);
+
+        // Create provider
+        $provider = $this->createProvider('provider');
+
+        // Create three entities
+        $entity1 = new EntityHasProviderStub('entity1', 'Acme Corp');
+        $entity2 = new EntityHasProviderStub('entity2', 'Acme Corp');
+        $entity3 = new EntityHasProviderStub('entity3', 'Acme Corp');
+
+        // Persist entities
+        $instance->persist($provider, $entity1);
+        $instance->persist($provider, $entity2);
+        $instance->persist($provider, $entity3);
+        $instance->flush($provider);
+
+        // Get ids for entities
+        $ids = [];
+        $ids[] = $entity1->getEntityId();
+        $ids[] = $entity2->getEntityId();
+        $ids[] = $entity3->getEntityId();
+
+        $result = $instance->findByIds($provider, $entity1, $ids);
+
+        self::assertCount(3, $result);
+        self::assertContains($entity1, $result);
+        self::assertContains($entity2, $result);
+        self::assertContains($entity3, $result);
+    }
+
+    /**
+     * Test find by id fails if composite primary key used
+     *
+     * @return void
+     */
+    public function testFindByIdsThrowsExceptionIfCompositePrimaryKeyUsed(): void
+    {
+        // Create doctrine instance and get filters
+        $doctrine = $this->getEntityManager();
+
+        // Create entity manager instance
+        $instance = $this->createInstance($doctrine);
+
+        // Create provider
+        $provider = $this->createProvider('provider');
+
+        // Create two entities, one with a composite primary key
+        $entity1 = new EntityHasProviderStub('entity1', 'Acme Corp');
+        $entity2 = new EntityHasCompositePrimaryKeyStub('entity2', 'Acme Corp');
+
+        // Persist entities
+        $instance->persist($provider, $entity1);
+        $instance->persist($provider, $entity2);
+        $instance->flush($provider);
+
+        // Create some random ids since it's not really important
+        $ids = ['test', 'random'];
+
+        $this->expectException(ORMException::class);
+
+        // Find on the composite primary key entity
+        $instance->findByIds($provider, $entity2, $ids);
+    }
+
     /**
      * Test flush binds (and removes) the subscriber
      *
@@ -35,8 +118,7 @@ final class EntityManagerTest extends DoctrineTestCase
 
         // Create entity
         $entity = new EntityHasProviderStub('entity', 'Acme Corp');
-        $entity->setProvider($provider);
-        $instance->persist($entity);
+        $instance->persist($provider, $entity);
         $instance->flush($provider);
 
         // Check subscriber was added
@@ -63,6 +145,35 @@ final class EntityManagerTest extends DoctrineTestCase
     }
 
     /**
+     * Test entity manager get filters returns our filters collection.
+     *
+     * @return void
+     */
+    public function testGetFiltersReturnsFilterCollection(): void
+    {
+        // Create doctrine instance and get filters
+        $doctrine = $this->getEntityManager();
+        $doctrineFilters = $doctrine->getFilters();
+
+        // Create filter
+        $filter = new FilterStub($this->getEntityManager());
+
+        // Add filter to doctrine
+        $config = $doctrine->getConfiguration();
+        $config->addFilter('test-filter', FilterStub::class);
+
+        // Create entity manager instance and get filters
+        $entityManager = $this->createInstance($doctrine);
+        $filters = $entityManager->getFilters();
+
+        // Enable filter
+        $filters->enable('test-filter');
+
+        // Test filter is returned
+        self::assertEquals($filter, $doctrineFilters->getEnabledFilters()['test-filter']);
+    }
+
+    /**
      * Test get repository method
      *
      * @return void
@@ -71,9 +182,53 @@ final class EntityManagerTest extends DoctrineTestCase
     {
         $instance = $this->createInstance();
 
-        $repository = $instance->getRepository(EntityHasProviderStub::class);
+        $repository = $instance->getRepository(EntityImplementsRepositoryInterfaceStub::class);
 
-        self::assertInstanceOf(EntityRepository::class, $repository);
+        self::assertInstanceOf(RepositoryInterface::class, $repository);
+    }
+
+    /**
+     * Test get repository throws an exception if interface is not implemented
+     *
+     * @return void
+     */
+    public function testGetRepositoryOnlyAllowsRepositoryInstances(): void
+    {
+        $instance = $this->createInstance();
+
+        $this->expectException(InvalidRepositoryException::class);
+
+        $instance->getRepository(EntityDoesNotImplementRepositoryInterfaceStub::class);
+    }
+
+    /**
+     * Test entity manager merge data into new entity from database.
+     *
+     * @return void
+     */
+    public function testMergeEntityWithDatabase(): void
+    {
+        $instance = $this->createInstance();
+
+        // Create provider
+        $provider = $this->createProvider('provider');
+
+        // Create entity
+        $entity = new EntityHasProviderStub('entity1', 'Acme Corp');
+
+        $instance->persist($provider, $entity);
+        $instance->flush($provider);
+
+        // Create a second entity with the same details as the first
+        $newEntity = new EntityHasProviderStub('entity2', 'Acme Corp');
+        $newEntity->setEntityId((string)$entity->getEntityId());
+
+        // Merge into database
+        $instance->merge($provider, $newEntity);
+
+        // Ensure external id was updated on original entity
+        self::assertSame('entity2', $newEntity->getExternalId());
+        self::assertSame($entity->getExternalId(), $newEntity->getExternalId());
     }
 
     /**
@@ -89,27 +244,26 @@ final class EntityManagerTest extends DoctrineTestCase
         $provider = $this->createProvider('provider');
 
         // Create entity
-        $entity = new EntityHasProviderStub('entity', 'Acme Corp');
-        $entity->setProvider($provider);
-        $instance->persist($entity);
+        $entity = new EntityImplementsRepositoryInterfaceStub('');
+        $instance->persist($provider, $entity);
         $instance->flush($provider);
 
         // Capture entity id
         $entityId = (string)$entity->getEntityId();
 
         // Create repository
-        $repository = $instance->getRepository(EntityHasProviderStub::class);
+        $repository = $instance->getRepository(EntityImplementsRepositoryInterfaceStub::class);
 
         // Make sure entity can be found
-        $found = $repository->find($entityId);
+        $found = $repository->find($provider, $entityId);
         self::assertSame($entity, $found);
 
         // Remove entity
-        $instance->remove($found);
+        $instance->remove($provider, $entity);
         $instance->flush($provider);
 
         // Check it no longer exists
-        $found = $repository->find($entityId);
+        $found = $repository->find($provider, $entityId);
         self::assertNull($found);
     }
 

--- a/tests/Unit/Externals/ORM/EntityManagerTest.php
+++ b/tests/Unit/Externals/ORM/EntityManagerTest.php
@@ -135,7 +135,8 @@ final class EntityManagerTest extends DoctrineTestCase
 
         $this->expectException(InvalidEntityException::class);
 
-        // Find on the composite primary key entity
+        // Mangle entity entirely
+        /** @noinspection PhpParamsInspection Invalid parameter is intentional */
         $instance->findByIds($provider, [], []);
     }
 

--- a/tests/Unit/Externals/ORM/Exceptions/InvalidRepositoryExceptionTest.php
+++ b/tests/Unit/Externals/ORM/Exceptions/InvalidRepositoryExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Unit\Externals\ORM\Exceptions;
+
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\InvalidRepositoryException;
+use Tests\LoyaltyCorp\Multitenancy\TestCases\AppTestCase;
+
+/**
+ * @covers \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\InvalidRepositoryException
+ */
+final class InvalidRepositoryExceptionTest extends AppTestCase
+{
+    /**
+     * Test exception returns the correct codes
+     *
+     * @return void
+     */
+    public function testExceptionCodes(): void
+    {
+        $exception = new InvalidRepositoryException();
+
+        self::assertSame(1129, $exception->getErrorCode());
+        self::assertSame(10, $exception->getErrorSubCode());
+    }
+}

--- a/tests/Unit/Externals/ORM/Exceptions/ORMExceptionTest.php
+++ b/tests/Unit/Externals/ORM/Exceptions/ORMExceptionTest.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Unit\Externals\ORM\Exceptions;
+
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException;
+use Tests\LoyaltyCorp\Multitenancy\TestCases\AppTestCase;
+
+/**
+ * @covers \LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException
+ */
+final class ORMExceptionTest extends AppTestCase
+{
+    /**
+     * Test exception returns the correct codes
+     *
+     * @return void
+     */
+    public function testExceptionCodes(): void
+    {
+        $exception = new ORMException();
+
+        self::assertSame(9029, $exception->getErrorCode());
+        self::assertSame(1, $exception->getErrorSubCode());
+        self::assertSame('A database error occurred.', $exception->getErrorMessage());
+    }
+}

--- a/tests/Unit/Externals/ORM/Query/FilterCollectionTest.php
+++ b/tests/Unit/Externals/ORM/Query/FilterCollectionTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Unit\Externals\ORM\Query;
+
+use LoyaltyCorp\Multitenancy\Externals\ORM\EntityManager;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException;
+use Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\Doctrine\ORM\Query\FilterStub;
+use Tests\LoyaltyCorp\Multitenancy\TestCases\DoctrineTestCase;
+
+/**
+ * @covers \LoyaltyCorp\Multitenancy\Externals\ORM\Query\FilterCollection
+ */
+class FilterCollectionTest extends DoctrineTestCase
+{
+    /**
+     * Test filters collection methods enable/disable filters on entity manager.
+     *
+     * @return void
+     */
+    public function testFiltersCollectionMethodsSuccessful(): void
+    {
+        // Create doctrine instance and get filters
+        $doctrine = $this->getEntityManager();
+        $doctrineFilters = $doctrine->getFilters();
+
+        // Add filter we can disable
+        $config = $doctrine->getConfiguration();
+        $config->addFilter('test-filter', FilterStub::class);
+
+        // Create entity manager instance and get filters
+        $entityManager = new EntityManager($doctrine);
+        $filters = $entityManager->getFilters();
+
+        // Test no filters are enabled
+        $enabled = $doctrineFilters->getEnabledFilters();
+        self::assertSame([], $enabled);
+
+        // Enable and test
+        $filters->enable('test-filter');
+        $enabled = $doctrineFilters->getEnabledFilters();
+        self::assertNotEmpty($enabled);
+        self::assertSame(['test-filter'], \array_keys($enabled));
+
+        // Disable and test
+        $filters->disable('test-filter');
+        $enabled = $doctrineFilters->getEnabledFilters();
+        self::assertSame([], $enabled);
+    }
+
+    /**
+     * Test an invalid filter throws an exception
+     *
+     * @return void
+     */
+    public function testInvalidFilterThrowsException(): void
+    {
+        $entityManager = new EntityManager($this->getEntityManager());
+        $filters = $entityManager->getFilters();
+
+        $this->expectException(ORMException::class);
+
+        $filters->enable('invalid');
+    }
+}

--- a/tests/Unit/Externals/ORM/RepositoryTest.php
+++ b/tests/Unit/Externals/ORM/RepositoryTest.php
@@ -1,0 +1,339 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Multitenancy\Unit\Externals\ORM;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use LoyaltyCorp\Multitenancy\Database\Entities\Provider;
+use LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\RepositoryInterface;
+use LoyaltyCorp\Multitenancy\Externals\ORM\EntityManager;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\InvalidRepositoryException;
+use LoyaltyCorp\Multitenancy\Externals\ORM\Exceptions\ORMException;
+use ReflectionClass;
+use Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityHasCompositePrimaryKeyStub;
+use Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityImplementsRepositoryInterfaceStub;
+use Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\RepositoryStub;
+use Tests\LoyaltyCorp\Multitenancy\TestCases\DoctrineTestCase;
+
+/**
+ * @covers \LoyaltyCorp\Multitenancy\Externals\ORM\Repository
+ */
+final class RepositoryTest extends DoctrineTestCase
+{
+    /**
+     * @var \Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityImplementsRepositoryInterfaceStub
+     */
+    private $entity1;
+
+    /**
+     * @var \Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityImplementsRepositoryInterfaceStub
+     */
+    private $entity2;
+
+    /**
+     * @var \Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityImplementsRepositoryInterfaceStub
+     */
+    private $entity3;
+
+    /**
+     * @var \Tests\LoyaltyCorp\Multitenancy\Integration\Stubs\Database\EntityImplementsRepositoryInterfaceStub
+     */
+    private $entity4;
+
+    /**
+     * Test count works with criteria and provider
+     *
+     * @return void
+     */
+    public function testCountFunctionality(): void
+    {
+        // Create two providers
+        $provider1 = $this->createProvider('provider1');
+        $provider2 = $this->createProvider('provider2');
+
+        // Create several entities
+        $this->createEntities($provider1, $provider2);
+
+        $instance = $this->createInstance();
+
+        // Test count provider 1
+        $count1 = $instance->count($provider1);
+        self::assertSame(3, $count1);
+
+        // Test count provider 2
+        $count2 = $instance->count($provider2);
+        self::assertSame(1, $count2);
+
+        // Test count with criteria
+        $countCriteria1 = $instance->count($provider1, ['string' => 'one']);
+        self::assertSame(2, $countCriteria1);
+
+        // Test count with criteria
+        $countCriteria2 = $instance->count($provider1, ['string' => 'two']);
+        self::assertSame(1, $countCriteria2);
+
+        // Test count with criteria with wrong provider
+        $countCriteria3 = $instance->count($provider2, ['string' => 'two']);
+        self::assertSame(0, $countCriteria3);
+    }
+
+    /**
+     * Test create query builder
+     *
+     * @return void
+     *
+     * @throws \ReflectionException If reflection does something whacky
+     */
+    public function testCreateQueryBuilderFunctionality(): void
+    {
+        $instance = $this->createInstance();
+
+        // Reflect so we can create a query builder
+        $reflected = new ReflectionClass(RepositoryStub::class);
+        $method = $reflected->getMethod('createQueryBuilder');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($instance, 'test');
+
+        self::assertSame(['test'], $result->getAllAliases());
+    }
+
+    /**
+     * Test exceptions thrown by doctrine are converted by the repository
+     *
+     * @return void
+     */
+    public function testExceptionsFromDoctrineAreConverted(): void
+    {
+        // Create two providers
+        $provider1 = $this->createProvider('provider1');
+        $provider2 = $this->createProvider('provider2');
+
+        // Create several entities
+        $this->createEntities($provider1, $provider2);
+
+        $instance = $this->createInstance();
+
+        $this->expectException(ORMException::class);
+
+        // Using an invalid property should throw an exception
+        $instance->count($provider1, ['invalidProperty' => 1]);
+    }
+
+    /**
+     * Test find all works with criteria and provider
+     *
+     * @return void
+     */
+    public function testFindAllFunctionality(): void
+    {
+        // Create two providers
+        $provider1 = $this->createProvider('provider1');
+        $provider2 = $this->createProvider('provider2');
+
+        // Create several entities
+        $this->createEntities($provider1, $provider2);
+
+        $instance = $this->createInstance();
+
+        // Test finding all entities for provider 1
+        $found1 = $instance->findAll($provider1);
+        self::assertSame([$this->entity1, $this->entity2, $this->entity3], $found1);
+
+        // Test finding all entities for provider 2
+        $found2 = $instance->findAll($provider2);
+        self::assertSame([$this->entity4], $found2);
+    }
+
+    /**
+     * Test find by works with criteria and provider
+     *
+     * @return void
+     */
+    public function testFindByFunctionality(): void
+    {
+        // Create two providers
+        $provider1 = $this->createProvider('provider1');
+        $provider2 = $this->createProvider('provider2');
+
+        // Create several entities
+        $this->createEntities($provider1, $provider2);
+
+        $instance = $this->createInstance();
+
+        // Test finding entities for provider 1
+        $found1 = $instance->findBy($provider1, []);
+        self::assertSame([$this->entity1, $this->entity2, $this->entity3], $found1);
+
+        // Test finding entities for provider 2
+        $found2 = $instance->findBy($provider2, []);
+        self::assertSame([$this->entity4], $found2);
+
+        // Test finding entities with criteria
+        $found3 = $instance->findBy($provider1, ['string' => 'one']);
+        self::assertSame([$this->entity1, $this->entity2], $found3);
+
+        // Test finding entities with criteria
+        $found4 = $instance->findBy($provider1, ['string' => 'two']);
+        self::assertSame([$this->entity3], $found4);
+
+        // Test finding entities with the wrong provider
+        $found5 = $instance->findBy($provider2, ['string' => 'two']);
+        self::assertSame([], $found5);
+    }
+
+    /**
+     * Test find works with criteria and provider
+     *
+     * @return void
+     */
+    public function testFindFunctionality(): void
+    {
+        // Create two providers
+        $provider1 = $this->createProvider('provider1');
+        $provider2 = $this->createProvider('provider2');
+
+        // Create several entities
+        $this->createEntities($provider1, $provider2);
+
+        $instance = $this->createInstance();
+
+        // Test finding an entity
+        $found1 = $instance->find($provider1, $this->entity1->getEntityId());
+        self::assertSame($this->entity1, $found1);
+
+        // Test provider mismatch
+        $found2 = $instance->find($provider2, $this->entity1->getEntityId());
+        self::assertNull($found2);
+    }
+
+    /**
+     * Test find one by works with criteria and provider
+     *
+     * @return void
+     */
+    public function testFindOneByFunctionality(): void
+    {
+        // Create two providers
+        $provider1 = $this->createProvider('provider1');
+        $provider2 = $this->createProvider('provider2');
+
+        // Create several entities
+        $this->createEntities($provider1, $provider2);
+
+        $instance = $this->createInstance();
+
+        // Test finding an entity for provider 1
+        $found1 = $instance->findOneBy($provider1, []);
+        self::assertSame($this->entity1, $found1);
+
+        // Test finding an entity for provider 2
+        $found2 = $instance->findOneBy($provider2, []);
+        self::assertSame($this->entity4, $found2);
+
+        // Test finding an entity with criteria
+        $found3 = $instance->findOneBy($provider1, ['string' => 'one']);
+        self::assertSame($this->entity1, $found3);
+
+        // Test finding an entity with criteria
+        $found4 = $instance->findOneBy($provider1, ['string' => 'two']);
+        self::assertSame($this->entity3, $found4);
+
+        // Test finding an entity with the wrong provider
+        $found5 = $instance->findOneBy($provider2, ['string' => 'two']);
+        self::assertNull($found5);
+    }
+
+    /**
+     * Test find works with criteria and provider
+     *
+     * @return void
+     */
+    public function testFindThrowsExceptionIfEntityUsesCompositeKeys(): void
+    {
+        // Create provider
+        $provider = $this->createProvider('provider');
+
+        $instance = $this->createInstance(EntityHasCompositePrimaryKeyStub::class);
+
+        $this->expectException(ORMException::class);
+
+        // Find should throw exception
+        $instance->find($provider, 1);
+    }
+
+    /**
+     * Test get class name functionality
+     *
+     * @return void
+     */
+    public function testGetClassNameReturnsEntityClass(): void
+    {
+        $instance = $this->createInstance(EntityHasCompositePrimaryKeyStub::class);
+
+        $name = $instance->getClassName();
+        self::assertSame(EntityHasCompositePrimaryKeyStub::class, $name);
+    }
+
+    /**
+     * Create repository instance
+     *
+     * @param string|null $class Class to instantiate repository for
+     *
+     * @return \LoyaltyCorp\Multitenancy\Externals\Interfaces\ORM\RepositoryInterface
+     */
+    protected function createInstance(?string $class = null): RepositoryInterface
+    {
+        $entityManager = new EntityManager($this->getEntityManager());
+
+        try {
+            return $entityManager->getRepository($class ?? EntityImplementsRepositoryInterfaceStub::class);
+        } catch (InvalidRepositoryException $exception) {
+            self::fail(\sprintf('Exception thrown when creating repository: %s', $exception->getMessage()));
+        }
+
+        return new RepositoryStub($this->getEntityManager(), new ClassMetadata(''));
+    }
+
+    /**
+     * Create entities for two providers
+     *
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider1
+     * @param \LoyaltyCorp\Multitenancy\Database\Entities\Provider $provider2
+     *
+     * @return void
+     */
+    private function createEntities(Provider $provider1, Provider $provider2): void
+    {
+        $this->entity1 = new EntityImplementsRepositoryInterfaceStub('one');
+        $this->entity2 = new EntityImplementsRepositoryInterfaceStub('one');
+        $this->entity3 = new EntityImplementsRepositoryInterfaceStub('two');
+        $this->entity4 = new EntityImplementsRepositoryInterfaceStub('one');
+
+        $entityManager = new EntityManager($this->getEntityManager());
+
+        $entityManager->persist($provider1, $this->entity1);
+        $entityManager->persist($provider1, $this->entity2);
+        $entityManager->persist($provider1, $this->entity3);
+        $entityManager->flush($provider1);
+
+        $entityManager->persist($provider2, $this->entity4);
+        $entityManager->flush($provider2);
+    }
+
+    /**
+     * Create a provider entity for testing
+     *
+     * @param string $externalId External id for the provider
+     *
+     * @return \LoyaltyCorp\Multitenancy\Database\Entities\Provider
+     */
+    private function createProvider(string $externalId): Provider
+    {
+        $provider = new Provider($externalId, 'Acme Corp');
+        $this->getEntityManager()->persist($provider);
+        $this->getEntityManager()->flush();
+
+        return $provider;
+    }
+}

--- a/tests/Unit/Externals/ORM/Subscribers/ProtectedFlushSubscriberTest.php
+++ b/tests/Unit/Externals/ORM/Subscribers/ProtectedFlushSubscriberTest.php
@@ -19,6 +19,8 @@ final class ProtectedFlushSubscriberTest extends DoctrineTestCase
      * Test the collections are checked for provider when cascading is automatic
      *
      * @return void
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException If provider clashes
      */
     public function testCollectionsAreCheckedForProviderMatches(): void
     {
@@ -80,6 +82,7 @@ final class ProtectedFlushSubscriberTest extends DoctrineTestCase
      * @return void
      *
      * @throws \LoyaltyCorp\Multitenancy\Database\Exceptions\InvalidEntityOwnershipException If provider mismatch
+     * @throws \LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException If provider clashes
      */
     public function testSubscriberThrowsExceptionIfProviderIdMismatchOnEntity(): void
     {
@@ -115,6 +118,8 @@ final class ProtectedFlushSubscriberTest extends DoctrineTestCase
      * Test subscriber unsets itself once successfully run
      *
      * @return void
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException If provider clashes
      */
     public function testSubscriberUnsetsItselfAfterSuccessfulRun(): void
     {
@@ -149,6 +154,8 @@ final class ProtectedFlushSubscriberTest extends DoctrineTestCase
      * Test subscriber unsets itself even if an exception is thrown
      *
      * @return void
+     *
+     * @throws \LoyaltyCorp\Multitenancy\Database\Exceptions\ProviderAlreadySetException If provider clashes
      */
     public function testSubscriberUnsetsItselfBeforeThrowningException(): void
     {


### PR DESCRIPTION
Ticket here: https://loyaltycorp.atlassian.net/browse/PYMT-981

This change forces a provider to be passed for all database actions and ensures that a provider mismatch is fatal. It reduces the need for the consumer to remember to set a provider or add provider to the criteria when retrieving records from the database.