### PR TITLE
Elasticsearch index name must be lowercase.

### DIFF
--- a/src/Services/Search/Transformers/ProviderIndexTransformer.php
+++ b/src/Services/Search/Transformers/ProviderIndexTransformer.php
@@ -33,7 +33,7 @@ final class ProviderIndexTransformer implements IndexTransformerInterface
     public function transformIndexName(EntitySearchHandlerInterface $handler, object $object): string
     {
         if (($handler instanceof ProviderAwareInterface) === true) {
-            return \sprintf('%s_%s', $handler->getIndexName(), $handler->getProviderId($object));
+            return \sprintf('%s_%s', $handler->getIndexName(), \mb_strtolower($handler->getProviderId($object)));
         }
 
         return $handler->getIndexName();
@@ -65,7 +65,7 @@ final class ProviderIndexTransformer implements IndexTransformerInterface
         $providers = $this->entityManager->getRepository(Provider::class)->findAll();
 
         foreach ($providers as $provider) {
-            $providerIds[] = $provider->getExternalId();
+            $providerIds[] = \mb_strtolower($provider->getExternalId());
         }
 
         return $providerIds;

--- a/src/Services/Search/Transformers/ProviderIndexTransformer.php
+++ b/src/Services/Search/Transformers/ProviderIndexTransformer.php
@@ -33,10 +33,10 @@ final class ProviderIndexTransformer implements IndexTransformerInterface
     public function transformIndexName(EntitySearchHandlerInterface $handler, object $object): string
     {
         if (($handler instanceof ProviderAwareInterface) === true) {
-            return \sprintf('%s_%s', $handler->getIndexName(), \mb_strtolower($handler->getProviderId($object)));
+            return \mb_strtolower(\sprintf('%s_%s', $handler->getIndexName(), $handler->getProviderId($object)));
         }
 
-        return $handler->getIndexName();
+        return \mb_strtolower($handler->getIndexName());
     }
 
     /**
@@ -48,7 +48,7 @@ final class ProviderIndexTransformer implements IndexTransformerInterface
         $providerIds = $this->fetchAllProviderIds();
 
         foreach ($providerIds as $providerId) {
-            $indexNames[] = \sprintf('%s_%s', $searchHandler->getIndexName(), $providerId);
+            $indexNames[] = \mb_strtolower(\sprintf('%s_%s', $searchHandler->getIndexName(), $providerId));
         }
 
         return $indexNames;
@@ -65,7 +65,7 @@ final class ProviderIndexTransformer implements IndexTransformerInterface
         $providers = $this->entityManager->getRepository(Provider::class)->findAll();
 
         foreach ($providers as $provider) {
-            $providerIds[] = \mb_strtolower($provider->getExternalId());
+            $providerIds[] = $provider->getExternalId();
         }
 
         return $providerIds;

--- a/tests/Unit/Services/Search/ProviderIndexTransformerTest.php
+++ b/tests/Unit/Services/Search/ProviderIndexTransformerTest.php
@@ -48,7 +48,7 @@ final class ProviderIndexTransformerTest extends AppTestCase
         $entityManager = new EntityManagerStub([$object]);
         $transformer = $this->getTransformer($entityManager);
 
-        $expectedIndexName = 'provider-aware-index_acmeIncId';
+        $expectedIndexName = 'provider-aware-index_acmeincid';
 
         $actualIndexName = $transformer->transformIndexName($handler, $object);
 
@@ -69,7 +69,7 @@ final class ProviderIndexTransformerTest extends AppTestCase
         $transformer = $this->getTransformer($entityManager);
 
         $expectedIndexNames = [
-            'provider-aware-index_xyzCorpId',
+            'provider-aware-index_xyzcorpid',
         ];
 
         $actualIndexNames = $transformer->transformIndexNames($handler);


### PR DESCRIPTION
There was a bug where if the index name is not all lower case it throws exception.

**Fix:**
Convert index name to lowercase in `ProviderIndexTransformer`