### PR TITLE
PYMT-1429 Add entity flush to new console command (create provider)

### DIFF
--- a/src/Bridge/Laravel/Console/Commands/CreateProviderCommand.php
+++ b/src/Bridge/Laravel/Console/Commands/CreateProviderCommand.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\Multitenancy\Bridge\Laravel\Console\Commands;
 
+use EoneoPay\Externals\ORM\Interfaces\EntityManagerInterface;
 use Illuminate\Console\Command;
 use LoyaltyCorp\Multitenancy\Bridge\Laravel\Console\Exceptions\CommandOptionUnusable;
 use LoyaltyCorp\Multitenancy\Services\Providers\Interfaces\ProviderServiceInterface;
@@ -25,17 +26,20 @@ final class CreateProviderCommand extends Command
     /**
      * Extract exception codes.
      *
+     * @param \EoneoPay\Externals\ORM\Interfaces\EntityManagerInterface $entityManager
      * @param \LoyaltyCorp\Multitenancy\Services\Providers\Interfaces\ProviderServiceInterface $providerService
      *
      * @return void
      *
      * @throws \LoyaltyCorp\Multitenancy\Bridge\Laravel\Console\Exceptions\CommandOptionUnusable
      */
-    public function handle(ProviderServiceInterface $providerService): void
+    public function handle(EntityManagerInterface $entityManager, ProviderServiceInterface $providerService): void
     {
         [$identifier, $name] = [$this->getOptionValue('identifier'), $this->getOptionValue('name')];
 
         $provider = $providerService->create($identifier, $name);
+
+        $entityManager->flush();
 
         $this->info('Provider has been created.');
         $this->table(

--- a/src/Bridge/Laravel/Console/Commands/CreateProviderCommand.php
+++ b/src/Bridge/Laravel/Console/Commands/CreateProviderCommand.php
@@ -17,8 +17,8 @@ final class CreateProviderCommand extends Command
     {
         $this->description = 'Create a new provider';
         $this->signature = 'app:provider:create 
-        {--identifier: The unique identifier for the provider to be referenced by} 
-        {--name: Human friendly name of the provider}';
+        {--identifier= : The unique identifier for the provider to be referenced by} 
+        {--name= : Human friendly name of the provider}';
 
         parent::__construct();
     }

--- a/tests/Unit/Bridge/Laravel/Console/Commands/CreateProviderCommandTest.php
+++ b/tests/Unit/Bridge/Laravel/Console/Commands/CreateProviderCommandTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Tests\LoyaltyCorp\Multitenancy\Stubs\Services\Providers\ProviderServiceStub;
+use Tests\LoyaltyCorp\Multitenancy\Stubs\Vendor\EoneoPay\Externals\ORM\EntityManagerStub;
 use Tests\LoyaltyCorp\Multitenancy\TestCases\Unit\CommandTestCase;
 
 /**
@@ -32,7 +33,7 @@ final class CreateProviderCommandTest extends CommandTestCase
         $this->expectExceptionMessage('Option \'identifier\' could not be resolved to a usable value');
 
         $command = $this->createInstance([]);
-        $command->handle(new ProviderServiceStub());
+        $command->handle(new EntityManagerStub(), new ProviderServiceStub());
     }
 
     /**
@@ -52,7 +53,7 @@ final class CreateProviderCommandTest extends CommandTestCase
         /** @var \Symfony\Component\Console\Output\BufferedOutput $output */
         $output = $command->getOutput();
 
-        $command->handle(new ProviderServiceStub());
+        $command->handle(new EntityManagerStub(), new ProviderServiceStub());
         $text = $output->fetch();
 
         self::assertStringContainsString('Provider has been created.', $text);
@@ -77,7 +78,7 @@ final class CreateProviderCommandTest extends CommandTestCase
         /** @var \Symfony\Component\Console\Output\BufferedOutput $output */
         $output = $command->getOutput();
 
-        $command->handle(new ProviderServiceStub());
+        $command->handle(new EntityManagerStub(), new ProviderServiceStub());
         $text = $output->fetch();
 
         self::assertStringContainsString('Provider has been created.', $text);


### PR DESCRIPTION
More of a bug-fix than feature, related to PR https://github.com/loyaltycorp/multitenancy/pull/28

Fixed:
- New console command not flushing
- Console option formatting to make Lumen happier